### PR TITLE
Number Verification integration using Network Enablement API and Vonage Virtual Operator

### DIFF
--- a/src/Prefix.tsx
+++ b/src/Prefix.tsx
@@ -2,13 +2,14 @@ import { useState } from 'react'
 import { InputAdornment, IconButton, Menu, MenuItem } from '@mui/material'
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 
-const EUROPEAN_PHONE_PREFIXES = ['+49', '+34', '+33', '+44']
+const EUROPEAN_PHONE_PREFIXES = ['+49', '+34', '+33', '+44', '+99']
 
 const PREFIX_FLAGS: Record<string, string> = {
   '+49': '🇩🇪', // Germany
   '+34': '🇪🇸', // Spain
   '+33': '🇫🇷', // France
   '+44': '🇬🇧', // United Kingdom
+  '+99': '🌍', // Virtual operator
 }
 
 interface PrefixProps {


### PR DESCRIPTION
Hi @diegotid,

Since we’ll be using the Vonage Virtual Operator and Number Verification API for the workshop, I realized the flow differs slightly from the one in your original implementation.

I’ve updated the logic based on the official documentation here:
https://developer.vonage.com/en/number-verification/getting-started

_Note_: I've also updatd the `prefix.tsx` file so that Virtual Numbers (+99 prefix) can be used for testing.

This is a first working version — not perfect yet, but functional. Happy to walk you through the changes if you’d like!

Thanks,
Anthony