### PR TITLE
Re-added missing state query param for /signup

### DIFF
--- a/src/Signup.tsx
+++ b/src/Signup.tsx
@@ -65,8 +65,9 @@ const Signup = () => {
   }, [isPhoneNumber, networkRequestId, phonePrefix, userId])
 
   const performSignup = useCallback(() => {
+    const params = new URLSearchParams(networkRequestId ? { state: networkRequestId } : {})
     setIsSubmitting(true)
-    fetch(`${import.meta.env.VITE_BACKEND_URL}/signup`, {
+    fetch(`${import.meta.env.VITE_BACKEND_URL}/signup?${params.toString()}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
the `/signup` endpoint on the backend still needs the state to be able to retrieve the phone number from the accessTokens Map.
If it's not sent, the phone number is not found and `/signup` always returns `{ verified: false }`.